### PR TITLE
Multiple result sets, and dbparam configuration.

### DIFF
--- a/EFCoreFluent/src/EFCoreFluent/EFExtensions.cs
+++ b/EFCoreFluent/src/EFCoreFluent/EFExtensions.cs
@@ -5,10 +5,12 @@ using System.Data.Common;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace EFCoreFluent
 {
-   public static class EFExtensions
+    public static class EFExtensions
     {
         /// <summary>
         /// Creates an initial DbCommand object based on a stored procedure name
@@ -23,6 +25,7 @@ namespace EFCoreFluent
             cmd.CommandType = System.Data.CommandType.StoredProcedure;
             return cmd;
         }
+
         /// <summary>
         /// Creates a DbParameter object and adds it to a DbCommand
         /// </summary>
@@ -30,7 +33,7 @@ namespace EFCoreFluent
         /// <param name="paramName"></param>
         /// <param name="paramValue"></param>
         /// <returns></returns>
-        public static DbCommand WithSqlParam(this DbCommand cmd, string paramName, object paramValue)
+        public static DbCommand WithSqlParam(this DbCommand cmd, string paramName, object paramValue, Action<DbParameter> configureParam = null)
         {
             if (string.IsNullOrEmpty(cmd.CommandText) && cmd.CommandType != System.Data.CommandType.StoredProcedure)
                 throw new InvalidOperationException("Call LoadStoredProc before using this method");
@@ -38,17 +41,102 @@ namespace EFCoreFluent
             var param = cmd.CreateParameter();
             param.ParameterName = paramName;
             param.Value = paramValue;
+            configureParam?.Invoke(param);
             cmd.Parameters.Add(param);
             return cmd;
         }
+
+        public static DbCommand WithSqlParam(this DbCommand cmd, string paramName, Action<DbParameter> configureParam = null)
+        {
+            if (string.IsNullOrEmpty(cmd.CommandText) && cmd.CommandType != System.Data.CommandType.StoredProcedure)
+                throw new InvalidOperationException("Call LoadStoredProc before using this method");
+
+            var param = cmd.CreateParameter();
+            param.ParameterName = paramName;
+            configureParam?.Invoke(param);
+            cmd.Parameters.Add(param);
+            return cmd;
+        }
+
+        public class SprocResults
+        {
+
+            //  private DbCommand _command;
+            private DbDataReader _reader;
+
+            public SprocResults(DbDataReader reader)
+            {
+                // _command = command;
+                _reader = reader;
+            }
+
+            public IList<T> ReadToList<T>()
+            {
+                return MapToList<T>(_reader);
+            }
+
+            public Task<bool> NextResultAsync()
+            {
+                return _reader.NextResultAsync();
+            }
+
+            public Task<bool> NextResultAsync(CancellationToken ct)
+            {
+                return _reader.NextResultAsync(ct);
+            }
+
+            public bool NextResult()
+            {
+                return _reader.NextResult();
+            }
+
+            /// <summary>
+            /// Retrieves the column values from the stored procedure and maps them to <typeparamref name="T"/>'s properties
+            /// </summary>
+            /// <typeparam name="T"></typeparam>
+            /// <param name="dr"></param>
+            /// <returns>IList<<typeparamref name="T"/>></returns>
+            private IList<T> MapToList<T>(DbDataReader dr)
+            {
+                var objList = new List<T>();
+                var props = typeof(T).GetRuntimeProperties();
+
+                var colMapping = dr.GetColumnSchema()
+                    .Where(x => props.Any(y => y.Name.ToLower() == x.ColumnName.ToLower()))
+                    .ToDictionary(key => key.ColumnName.ToLower());
+
+                if (dr.HasRows)
+                {
+                    while (dr.Read())
+                    {
+                        T obj = Activator.CreateInstance<T>();
+                        foreach (var prop in props)
+                        {
+                            var val = dr.GetValue(colMapping[prop.Name.ToLower()].ColumnOrdinal.Value);
+                            prop.SetValue(obj, val == DBNull.Value ? null : val);
+                        }
+                        objList.Add(obj);
+                    }
+                }
+                return objList;
+            }
+
+
+        }
+
         /// <summary>
         /// Executes a DbDataReader and returns a list of mapped column values to the properties of <typeparamref name="T"/>
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="command"></param>
         /// <returns></returns>
-        public static IList<T> ExecuteStoredProc<T>(this DbCommand command)
+        public static void ExecuteStoredProc(this DbCommand command, Action<SprocResults> handleResults, System.Data.CommandBehavior commandBehaviour = System.Data.CommandBehavior.Default)
         {
+            if (handleResults == null)
+            {
+                throw new ArgumentNullException(nameof(handleResults));
+            }
+
             using (command)
             {
                 if (command.Connection.State == System.Data.ConnectionState.Closed)
@@ -57,7 +145,9 @@ namespace EFCoreFluent
                 {
                     using (var reader = command.ExecuteReader())
                     {
-                        return reader.MapToList<T>();
+                        var sprocResults = new SprocResults(reader);
+                        // return new SprocResults();
+                        handleResults(sprocResults);
                     }
                 }
                 finally
@@ -66,36 +156,6 @@ namespace EFCoreFluent
                 }
             }
         }
-        /// <summary>
-        /// Retrieves the column values from the stored procedure and maps them to <typeparamref name="T"/>'s properties
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="dr"></param>
-        /// <returns>IList<<typeparamref name="T"/>></returns>
-        private static IList<T> MapToList<T>(this DbDataReader dr)
-        {
-            var objList = new List<T>();
-            var props = typeof(T).GetRuntimeProperties();
 
-            var colMapping = dr.GetColumnSchema()
-                .Where(x => props.Any(y => y.Name.ToLower() == x.ColumnName.ToLower()))
-                .ToDictionary(key => key.ColumnName.ToLower());
-
-            if (dr.HasRows)
-            {
-                while (dr.Read())
-                {
-                    T obj = Activator.CreateInstance<T>();
-                    foreach (var prop in props)
-                    {
-                        var val = dr.GetValue(colMapping[prop.Name.ToLower()].ColumnOrdinal.Value);
-                        prop.SetValue(obj, val == DBNull.Value ? null : val);
-                    }
-                    objList.Add(obj);
-                }
-            }
-            return objList;
-        }
     }
-}
 }


### PR DESCRIPTION
Closes #1 and Closes #2

This slightly changes the usage / API to become:

```
          dbContext.LoadStoredProc("dbo.SomeSproc")
                .WithSqlParam("fooId", userDeviceClientApplicationVersionMapId)              
                .WithSqlParam("barId", (dbParam) =>
                {
                    dbParam.Direction = System.Data.ParameterDirection.Output;
                })
                .ExecuteStoredProc((handler) =>
                {                  
                    var fooResults = handler.ReadToList<FooDto>();
                    handler.NextResult();
                    var barResults = handler.ReadToList<BarDto>();
                    handler.NextResult();
                    var bazResults = handler.ReadToList<BazDto>();                 
                });
```