### PR TITLE
Update EFExtensions.cs

### DIFF
--- a/EFCoreFluent/src/EFCoreFluent/EFExtensions.cs
+++ b/EFCoreFluent/src/EFCoreFluent/EFExtensions.cs
@@ -49,7 +49,7 @@ namespace Snickler.EFCore
 
             var param = cmd.CreateParameter();
             param.ParameterName = paramName;
-            param.Value = paramValue;
+            param.Value = (paramValue != null ? paramValue : DBNull.Value);
             configureParam?.Invoke(param);
             cmd.Parameters.Add(param);
             return cmd;


### PR DESCRIPTION
Changed line 52 to handle null values. Otherwise the parameter disappears and an exception is thrown when calling a stored procedure that has parameters that accept null.