### PR TITLE
Allow users to manage connections outside of library

### DIFF
--- a/EFCoreFluent/src/EFCoreFluent/EFExtensions.cs
+++ b/EFCoreFluent/src/EFCoreFluent/EFExtensions.cs
@@ -194,7 +194,7 @@ namespace Snickler.EFCore
         /// <typeparam name="T"></typeparam>
         /// <param name="command"></param>
         /// <returns></returns>
-        public static void ExecuteStoredProc(this DbCommand command, Action<SprocResults> handleResults, System.Data.CommandBehavior commandBehaviour = System.Data.CommandBehavior.Default)
+        public static void ExecuteStoredProc(this DbCommand command, Action<SprocResults> handleResults, System.Data.CommandBehavior commandBehaviour = System.Data.CommandBehavior.Default, bool manageConnection = true)
         {
             if (handleResults == null)
             {
@@ -203,7 +203,7 @@ namespace Snickler.EFCore
 
             using (command)
             {
-                if (command.Connection.State == System.Data.ConnectionState.Closed)
+                if (command.Connection.State == System.Data.ConnectionState.Closed && manageConnection)
                     command.Connection.Open();
                 try
                 {
@@ -216,7 +216,10 @@ namespace Snickler.EFCore
                 }
                 finally
                 {
-                    command.Connection.Close();
+                    if(manageConnection)
+                    {
+                        command.Connection.Close();
+                    }
                 }
             }
         }
@@ -227,7 +230,7 @@ namespace Snickler.EFCore
         /// <typeparam name="T"></typeparam>
         /// <param name="command"></param>
         /// <returns></returns>
-        public async static Task ExecuteStoredProcAsync(this DbCommand command, Action<SprocResults> handleResults, System.Data.CommandBehavior commandBehaviour = System.Data.CommandBehavior.Default, CancellationToken ct = default(CancellationToken))
+        public async static Task ExecuteStoredProcAsync(this DbCommand command, Action<SprocResults> handleResults, System.Data.CommandBehavior commandBehaviour = System.Data.CommandBehavior.Default, CancellationToken ct = default(CancellationToken), bool manageConnection = true)
         {
             if (handleResults == null)
             {
@@ -236,7 +239,7 @@ namespace Snickler.EFCore
 
             using (command)
             {
-                if (command.Connection.State == System.Data.ConnectionState.Closed)
+                if (command.Connection.State == System.Data.ConnectionState.Closed && manageConnection)
                     await command.Connection.OpenAsync(ct).ConfigureAwait(false);
                 try
                 {
@@ -248,7 +251,10 @@ namespace Snickler.EFCore
                 }
                 finally
                 {
-                    command.Connection.Close();
+                    if (manageConnection)
+                    {
+                        command.Connection.Close();
+                    }
                 }
             }
         }

--- a/EFCoreFluent/src/EFCoreFluent/EFExtensions.cs
+++ b/EFCoreFluent/src/EFCoreFluent/EFExtensions.cs
@@ -203,7 +203,7 @@ namespace Snickler.EFCore
 
             using (command)
             {
-                if (command.Connection.State == System.Data.ConnectionState.Closed && manageConnection)
+                if (manageConnection && command.Connection.State == System.Data.ConnectionState.Closed)
                     command.Connection.Open();
                 try
                 {
@@ -239,7 +239,7 @@ namespace Snickler.EFCore
 
             using (command)
             {
-                if (command.Connection.State == System.Data.ConnectionState.Closed && manageConnection)
+                if (manageConnection && command.Connection.State == System.Data.ConnectionState.Closed)
                     await command.Connection.OpenAsync(ct).ConfigureAwait(false);
                 try
                 {


### PR DESCRIPTION
These changes will allow users to manage connections outside of this library.

I'm working with a framework right now that manages connections and the ExecuteStoredProcedure methods closing the connection was causing a lot of issues. This change is backwards compatible and preserves the original behavior by default. 

Thanks!