### PR TITLE
Read column names from ColumnAttribute if present

### DIFF
--- a/EFCoreFluent/src/EFCoreFluent/EFExtensions.cs
+++ b/EFCoreFluent/src/EFCoreFluent/EFExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
 using System.Data;
 using System.Data.Common;
 using System.Linq;
@@ -175,7 +176,7 @@ namespace Snickler.EFCore
                     var obj = new T();
                     foreach (var prop in props)
                     {
-                        var upperName = prop.Name.ToUpper();
+                        var upperName = (prop.GetCustomAttribute<ColumnAttribute>(true)?.Name ?? prop.Name).ToUpper();
 
                         if (!colMapping.ContainsKey(upperName))
                             continue;


### PR DESCRIPTION
Please test and integrate, this should solve the issue of having different property names from the stored procedure columns. Necessary when your stored procedure columns have things like spaces in them (not best practice I know, but unfortunately not uncommon in real world applications).